### PR TITLE
cors header for matrix client config

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,2 @@
+/.well-known/matrix/client
+  Access-Control-Allow-Origin: *


### PR DESCRIPTION
**Describe what changes this pull request brings**

> The client .well-known file needs the CORS header Access-Control-Allow-Origin: * enabled on your web server. Please see enable-cors.org for additional information.