### PR TITLE
set www.vshn.ch as siteUrl since netlify redirects everything to www.…

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,7 +53,7 @@ steps:
     image: node:14.13.1-slim
     environment:
       WP_GRAPHQL_URL: https://vshn.cyon.site/graphql
-      GATSBY_DEFAULT_SITE_URL: https://vshn.ch/
+      GATSBY_DEFAULT_SITE_URL: https://www.vshn.ch/
       GATSBY_CONCURRENT_DOWNLOAD: 5
       WP_HTACCESS_USERNAME: vshn
       WP_HTACCESS_PASSWORD:


### PR DESCRIPTION
**Describe what changes this pull request brings**

This pull requests fixes the siteUrl from https://vshn.ch to https://www.vshn.ch, which should affect the URLs in RSS-feeds and sitemap.xml. Most "normal links" on the website use relative links though so they are not affected.

The reason for fixing it is that netlify redirects all requests to https://www.vshn.ch anyway, so the links in RSS feeds and Sitemap.xml all needed to be redirected again.
