### PR TITLE
feat: update gatsby-source-wp to latest stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "gatsby-image": "^3.11.0",
         "gatsby-plugin-feed": "^4.7.0",
         "gatsby-plugin-image": "^2.7.0",
-        "gatsby-source-wordpress": "^6.7.0-alpha-gatsby-source-wordpress.7",
+        "gatsby-source-wordpress": "^6.8.0",
         "html-react-parser": "^1.4.2",
         "lottie-web": "5.8.1",
         "normalize.css": "^8.0.1",
@@ -13100,12 +13100,15 @@
       }
     },
     "node_modules/color": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
-      "integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.1.tgz",
+      "integrity": "sha512-MFJr0uY4RvTQUKvPq7dh9grVOTYSFeXja2mBXioCGjnjJoXrAp9jJ1NQTDR73c9nwBSAQiNKloKl5zq9WB9UPw==",
       "dependencies": {
         "color-convert": "^2.0.1",
-        "color-string": "^1.6.0"
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
       }
     },
     "node_modules/color-convert": {
@@ -13122,9 +13125,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "node_modules/color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -18110,9 +18113,9 @@
       }
     },
     "node_modules/gatsby-core-utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.7.0.tgz",
-      "integrity": "sha512-CboIzpEFbaD4+WrozKl3fMpxUetcaDq0aWPfrfzAtc8l0JMlD3GS2Q/uW7HpcvTAlSGv2ZomTzd2ySLV/AgpTQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.8.0.tgz",
+      "integrity": "sha512-OUuTvEcC5cygLyDAmib+Je1txtNc9X8sV8QcKqWepUYXGySIzCaowBh55vn97wXmdYpUNOa3PXIMR+KsBfA2Rw==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -18121,14 +18124,36 @@
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
         "got": "^11.8.3",
+        "import-from": "^4.0.0",
+        "lmdb": "^2.1.7",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
+        "resolve-from": "^5.0.0",
         "tmp": "^0.2.1",
         "xdg-basedir": "^4.0.0"
       },
       "engines": {
         "node": ">=14.15.0"
+      }
+    },
+    "node_modules/gatsby-core-utils/node_modules/import-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==",
+      "engines": {
+        "node": ">=12.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gatsby-core-utils/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/gatsby-graphiql-explorer": {
@@ -18223,9 +18248,9 @@
       }
     },
     "node_modules/gatsby-plugin-catch-links": {
-      "version": "4.7.0-next.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-4.7.0-next.0.tgz",
-      "integrity": "sha512-7PUAxqZM11PoWKFdjwMUdXXMQF2BQ7TSi0n7a+yYFfw2eMyL3sVikGRc69lbGxUAV7vdabfNal8DPbUP+ONiNA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-4.8.0.tgz",
+      "integrity": "sha512-AErfHium3wTj8ojxV9rO9Q9q4fUwrqAqnavLJHFIx+aQuQpE4jF8HL9efyUdbXwwkdPETm1I0kTdxYGTGGEknw==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "escape-string-regexp": "^1.0.5"
@@ -18900,16 +18925,15 @@
       }
     },
     "node_modules/gatsby-source-filesystem": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.6.0.tgz",
-      "integrity": "sha512-Ve6VfFJ4moTX7n8uDTGF7K07HdjWkWW7c9Bn1etcS2QcFRRMj/lxQ/2EFpgVM20jtZ60IG1vqnAzDabqz7UxXQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.8.0.tgz",
+      "integrity": "sha512-krznULFMtmfJStcy18dcNCv8dFW1e62JTaTMzqz9LdC8cEimqeKn2sz4i0ZZhfVPzdhkl8pUg0Re4yVbtR53ww==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "chokidar": "^3.5.2",
-        "fastq": "^1.13.0",
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.6.0",
+        "gatsby-core-utils": "^3.8.0",
         "got": "^9.6.0",
         "md5-file": "^5.0.0",
         "mime": "^2.5.2",
@@ -18958,9 +18982,9 @@
       }
     },
     "node_modules/gatsby-source-wordpress": {
-      "version": "6.7.0-alpha-gatsby-source-wordpress.7",
-      "resolved": "https://registry.npmjs.org/gatsby-source-wordpress/-/gatsby-source-wordpress-6.7.0-alpha-gatsby-source-wordpress.7.tgz",
-      "integrity": "sha512-VMYePdxmbw+kWnZ+pkWM9v6pUJ3e5acmcXkRR/dJrzYpKNXqb83Pf1KDShiVN4SnxMWOGm3+in2KUouJAmvBTw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-wordpress/-/gatsby-source-wordpress-6.8.0.tgz",
+      "integrity": "sha512-tfPMLNSKxFkN4RBRjTH53xVZoy0aVaRxAPZCB/LDehFTh1dfl6ktVDyBZsSybAFXKL+J8jz5rff4ui3wnqv70w==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@rematch/core": "^1.4.0",
@@ -18983,9 +19007,9 @@
         "file-type": "^15.0.1",
         "filesize": "^6.4.0",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "3.7.0-next.1",
-        "gatsby-plugin-catch-links": "4.7.0-next.0",
-        "gatsby-source-filesystem": "4.7.0-next.1",
+        "gatsby-core-utils": "^3.8.0",
+        "gatsby-plugin-catch-links": "^4.8.0",
+        "gatsby-source-filesystem": "^4.8.0",
         "glob": "^7.2.0",
         "got": "^11.8.3",
         "lodash": "^4.17.21",
@@ -18995,7 +19019,7 @@
         "read-chunk": "^3.2.0",
         "replaceall": "^0.1.6",
         "semver": "^7.3.5",
-        "sharp": "^0.29.3",
+        "sharp": "^0.30.1",
         "valid-url": "^1.0.9"
       },
       "engines": {
@@ -19026,6 +19050,14 @@
         "async": "3.2.0",
         "lodash": "^4.17.21",
         "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/gatsby-source-wordpress/node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/gatsby-source-wordpress/node_modules/diff": {
@@ -19061,189 +19093,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-core-utils": {
-      "version": "3.7.0-next.1",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.7.0-next.1.tgz",
-      "integrity": "sha512-xcMRfa1bNs9jTnc5VIrN2AJDQ4DQM4QjI/1iXKAzRfplbaUu4wMgaucwVv3h2GJjOXP1NSeLRIa9eHrLuFxhxQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "ci-info": "2.0.0",
-        "configstore": "^5.0.1",
-        "fastq": "^1.13.0",
-        "file-type": "^16.5.3",
-        "fs-extra": "^10.0.0",
-        "got": "^11.8.3",
-        "lock": "^1.1.0",
-        "node-object-hash": "^2.3.10",
-        "proper-lockfile": "^4.1.2",
-        "tmp": "^0.2.1",
-        "xdg-basedir": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-core-utils/node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-core-utils/node_modules/file-type": {
-      "version": "16.5.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
-      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-core-utils/node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-core-utils/node_modules/token-types": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
-      "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-source-filesystem": {
-      "version": "4.7.0-next.1",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.7.0-next.1.tgz",
-      "integrity": "sha512-ozFfO11uDdBfMY7cg9EuZ4Eb7sd/NdxiVRMN6aPRIeJjO9kLtJDXUCsItZDzMAqtqHDcxifyVLidBn/EWxKhuA==",
-      "dependencies": {
-        "@babel/runtime": "^7.15.4",
-        "chokidar": "^3.5.2",
-        "file-type": "^16.5.3",
-        "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.7.0-next.1",
-        "got": "^9.6.0",
-        "md5-file": "^5.0.0",
-        "mime": "^2.5.2",
-        "pretty-bytes": "^5.4.1",
-        "progress": "^2.0.3",
-        "valid-url": "^1.0.9",
-        "xstate": "^4.26.1"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^4.0.0-next"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-source-filesystem/node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-source-filesystem/node_modules/file-type": {
-      "version": "16.5.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
-      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "^6.2.4",
-        "token-types": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-source-filesystem/node_modules/got": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-      "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "dependencies": {
-        "@sindresorhus/is": "^0.14.0",
-        "@szmarczak/http-timer": "^1.1.2",
-        "cacheable-request": "^6.0.0",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^4.1.0",
-        "lowercase-keys": "^1.0.1",
-        "mimic-response": "^1.0.1",
-        "p-cancelable": "^1.0.0",
-        "to-readable-stream": "^1.0.0",
-        "url-parse-lax": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-source-filesystem/node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/gatsby-source-filesystem/node_modules/token-types": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
-      "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/gatsby-source-wordpress/node_modules/get-stream": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/gatsby-source-wordpress/node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -19267,6 +19116,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
       "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
+    },
+    "node_modules/gatsby-source-wordpress/node_modules/sharp": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.1.tgz",
+      "integrity": "sha512-ycpz81q8AeVjz1pGvvirQBeJcYE2sXAjcLXR/69LWOe/oxavBLOrenZcTzvTXn83jqAGqY+OuwF+2kFXzbKtDA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.0",
+        "detect-libc": "^2.0.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1",
+        "semver": "^7.3.5",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^2.1.1",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/gatsby-source-wordpress/node_modules/token-types": {
       "version": "2.1.1",
@@ -22483,6 +22354,19 @@
         "enquirer": ">= 2.3.0 < 3"
       }
     },
+    "node_modules/lmdb": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.2.tgz",
+      "integrity": "sha512-ih7wahPRxy19T+r6/vN9UfdpDfIPXlLL/PkRVkDuNPA/MNGZIiGM/v1zUyhC/+4sveponuQRHVObt8sTVrW8rw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      }
+    },
     "node_modules/lmdb-store": {
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/lmdb-store/-/lmdb-store-1.6.13.tgz",
@@ -23889,10 +23773,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msgpackr": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.0.tgz",
-      "integrity": "sha512-GWMowA95SOMkrFM+uKF/9MOIoZbDwoZ09XEqSoOwyt/IzohTfxfOJrIGW0fInvcZUEoZ0wHCwVg4K0UOOUA49A==",
-      "optional": true,
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.4.tgz",
+      "integrity": "sha512-Z7w5Jg+2Q9z9gJxeM68d7tSuWZZGnFIRhZnyqcZCa/1dKkhOCNvR1TUV3zzJ3+vj78vlwKRzUgVDlW4jiSOeDA==",
       "optionalDependencies": {
         "msgpackr-extract": "^1.0.14"
       }
@@ -24057,9 +23940,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
-      "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node_modules/node-dir": {
       "version": "0.1.17",
@@ -24625,9 +24508,9 @@
       }
     },
     "node_modules/ordered-binary": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.1.3.tgz",
-      "integrity": "sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.4.tgz",
+      "integrity": "sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg=="
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
@@ -26411,11 +26294,11 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
-      "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
+      "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
       "dependencies": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
@@ -26434,6 +26317,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/prelude-ls": {
@@ -29079,9 +28970,9 @@
       ]
     },
     "node_modules/simple-get": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
-      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "funding": [
         {
           "type": "github",
@@ -32982,9 +32873,9 @@
       }
     },
     "node_modules/weak-lru-cache": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.1.3.tgz",
-      "integrity": "sha512-5LDIv+sr6uzT94Hhcq7Qv7gt3jxol4iMWUqOgJSLYbB5oO7bTSMqIBtKsytm8N2BufYOdJw86/qu+SDfbo/wKQ=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
+      "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
     },
     "node_modules/web-namespaces": {
       "version": "1.1.4",
@@ -43915,12 +43806,12 @@
       }
     },
     "color": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.0.1.tgz",
-      "integrity": "sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.1.tgz",
+      "integrity": "sha512-MFJr0uY4RvTQUKvPq7dh9grVOTYSFeXja2mBXioCGjnjJoXrAp9jJ1NQTDR73c9nwBSAQiNKloKl5zq9WB9UPw==",
       "requires": {
         "color-convert": "^2.0.1",
-        "color-string": "^1.6.0"
+        "color-string": "^1.9.0"
       },
       "dependencies": {
         "color-convert": {
@@ -43952,9 +43843,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
       "requires": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -48047,9 +47938,9 @@
       }
     },
     "gatsby-core-utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.7.0.tgz",
-      "integrity": "sha512-CboIzpEFbaD4+WrozKl3fMpxUetcaDq0aWPfrfzAtc8l0JMlD3GS2Q/uW7HpcvTAlSGv2ZomTzd2ySLV/AgpTQ==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.8.0.tgz",
+      "integrity": "sha512-OUuTvEcC5cygLyDAmib+Je1txtNc9X8sV8QcKqWepUYXGySIzCaowBh55vn97wXmdYpUNOa3PXIMR+KsBfA2Rw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "ci-info": "2.0.0",
@@ -48058,11 +47949,26 @@
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
         "got": "^11.8.3",
+        "import-from": "^4.0.0",
+        "lmdb": "^2.1.7",
         "lock": "^1.1.0",
         "node-object-hash": "^2.3.10",
         "proper-lockfile": "^4.1.2",
+        "resolve-from": "^5.0.0",
         "tmp": "^0.2.1",
         "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "import-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
+          "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ=="
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
       }
     },
     "gatsby-graphiql-explorer": {
@@ -48135,9 +48041,9 @@
       }
     },
     "gatsby-plugin-catch-links": {
-      "version": "4.7.0-next.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-4.7.0-next.0.tgz",
-      "integrity": "sha512-7PUAxqZM11PoWKFdjwMUdXXMQF2BQ7TSi0n7a+yYFfw2eMyL3sVikGRc69lbGxUAV7vdabfNal8DPbUP+ONiNA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-4.8.0.tgz",
+      "integrity": "sha512-AErfHium3wTj8ojxV9rO9Q9q4fUwrqAqnavLJHFIx+aQuQpE4jF8HL9efyUdbXwwkdPETm1I0kTdxYGTGGEknw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "escape-string-regexp": "^1.0.5"
@@ -48620,16 +48526,15 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.6.0.tgz",
-      "integrity": "sha512-Ve6VfFJ4moTX7n8uDTGF7K07HdjWkWW7c9Bn1etcS2QcFRRMj/lxQ/2EFpgVM20jtZ60IG1vqnAzDabqz7UxXQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.8.0.tgz",
+      "integrity": "sha512-krznULFMtmfJStcy18dcNCv8dFW1e62JTaTMzqz9LdC8cEimqeKn2sz4i0ZZhfVPzdhkl8pUg0Re4yVbtR53ww==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "chokidar": "^3.5.2",
-        "fastq": "^1.13.0",
         "file-type": "^16.5.3",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.6.0",
+        "gatsby-core-utils": "^3.8.0",
         "got": "^9.6.0",
         "md5-file": "^5.0.0",
         "mime": "^2.5.2",
@@ -48668,9 +48573,9 @@
       }
     },
     "gatsby-source-wordpress": {
-      "version": "6.7.0-alpha-gatsby-source-wordpress.7",
-      "resolved": "https://registry.npmjs.org/gatsby-source-wordpress/-/gatsby-source-wordpress-6.7.0-alpha-gatsby-source-wordpress.7.tgz",
-      "integrity": "sha512-VMYePdxmbw+kWnZ+pkWM9v6pUJ3e5acmcXkRR/dJrzYpKNXqb83Pf1KDShiVN4SnxMWOGm3+in2KUouJAmvBTw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-wordpress/-/gatsby-source-wordpress-6.8.0.tgz",
+      "integrity": "sha512-tfPMLNSKxFkN4RBRjTH53xVZoy0aVaRxAPZCB/LDehFTh1dfl6ktVDyBZsSybAFXKL+J8jz5rff4ui3wnqv70w==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@rematch/core": "^1.4.0",
@@ -48693,9 +48598,9 @@
         "file-type": "^15.0.1",
         "filesize": "^6.4.0",
         "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "3.7.0-next.1",
-        "gatsby-plugin-catch-links": "4.7.0-next.0",
-        "gatsby-source-filesystem": "4.7.0-next.1",
+        "gatsby-core-utils": "^3.8.0",
+        "gatsby-plugin-catch-links": "^4.8.0",
+        "gatsby-source-filesystem": "^4.8.0",
         "glob": "^7.2.0",
         "got": "^11.8.3",
         "lodash": "^4.17.21",
@@ -48705,7 +48610,7 @@
         "read-chunk": "^3.2.0",
         "replaceall": "^0.1.6",
         "semver": "^7.3.5",
-        "sharp": "^0.29.3",
+        "sharp": "^0.30.1",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
@@ -48729,6 +48634,11 @@
             "lru-cache": "6.0.0"
           }
         },
+        "detect-libc": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+          "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+        },
         "diff": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -48750,138 +48660,6 @@
           "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.4.0.tgz",
           "integrity": "sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ=="
         },
-        "gatsby-core-utils": {
-          "version": "3.7.0-next.1",
-          "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-3.7.0-next.1.tgz",
-          "integrity": "sha512-xcMRfa1bNs9jTnc5VIrN2AJDQ4DQM4QjI/1iXKAzRfplbaUu4wMgaucwVv3h2GJjOXP1NSeLRIa9eHrLuFxhxQ==",
-          "requires": {
-            "@babel/runtime": "^7.15.4",
-            "ci-info": "2.0.0",
-            "configstore": "^5.0.1",
-            "fastq": "^1.13.0",
-            "file-type": "^16.5.3",
-            "fs-extra": "^10.0.0",
-            "got": "^11.8.3",
-            "lock": "^1.1.0",
-            "node-object-hash": "^2.3.10",
-            "proper-lockfile": "^4.1.2",
-            "tmp": "^0.2.1",
-            "xdg-basedir": "^4.0.0"
-          },
-          "dependencies": {
-            "@tokenizer/token": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-              "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-            },
-            "file-type": {
-              "version": "16.5.3",
-              "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
-              "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
-              "requires": {
-                "readable-web-to-node-stream": "^3.0.0",
-                "strtok3": "^6.2.4",
-                "token-types": "^4.1.1"
-              }
-            },
-            "readable-web-to-node-stream": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-              "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-              "requires": {
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "token-types": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
-              "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
-              "requires": {
-                "@tokenizer/token": "^0.3.0",
-                "ieee754": "^1.2.1"
-              }
-            }
-          }
-        },
-        "gatsby-source-filesystem": {
-          "version": "4.7.0-next.1",
-          "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-4.7.0-next.1.tgz",
-          "integrity": "sha512-ozFfO11uDdBfMY7cg9EuZ4Eb7sd/NdxiVRMN6aPRIeJjO9kLtJDXUCsItZDzMAqtqHDcxifyVLidBn/EWxKhuA==",
-          "requires": {
-            "@babel/runtime": "^7.15.4",
-            "chokidar": "^3.5.2",
-            "file-type": "^16.5.3",
-            "fs-extra": "^10.0.0",
-            "gatsby-core-utils": "^3.7.0-next.1",
-            "got": "^9.6.0",
-            "md5-file": "^5.0.0",
-            "mime": "^2.5.2",
-            "pretty-bytes": "^5.4.1",
-            "progress": "^2.0.3",
-            "valid-url": "^1.0.9",
-            "xstate": "^4.26.1"
-          },
-          "dependencies": {
-            "@tokenizer/token": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-              "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
-            },
-            "file-type": {
-              "version": "16.5.3",
-              "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
-              "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
-              "requires": {
-                "readable-web-to-node-stream": "^3.0.0",
-                "strtok3": "^6.2.4",
-                "token-types": "^4.1.1"
-              }
-            },
-            "got": {
-              "version": "9.6.0",
-              "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
-              "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-              "requires": {
-                "@sindresorhus/is": "^0.14.0",
-                "@szmarczak/http-timer": "^1.1.2",
-                "cacheable-request": "^6.0.0",
-                "decompress-response": "^3.3.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^4.1.0",
-                "lowercase-keys": "^1.0.1",
-                "mimic-response": "^1.0.1",
-                "p-cancelable": "^1.0.0",
-                "to-readable-stream": "^1.0.0",
-                "url-parse-lax": "^3.0.0"
-              }
-            },
-            "readable-web-to-node-stream": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-              "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-              "requires": {
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "token-types": {
-              "version": "4.1.1",
-              "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
-              "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
-              "requires": {
-                "@tokenizer/token": "^0.3.0",
-                "ieee754": "^1.2.1"
-              }
-            }
-          }
-        },
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
         "node-fetch": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -48894,6 +48672,21 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-2.0.0.tgz",
           "integrity": "sha512-+oZJurc4hXpaaqsN68GoZGQAQIA3qr09Or4fqEsargABnbe5Aau8hFn6ISVleT3cpY/0n/8drn7huyyEvTbghA=="
+        },
+        "sharp": {
+          "version": "0.30.1",
+          "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.1.tgz",
+          "integrity": "sha512-ycpz81q8AeVjz1pGvvirQBeJcYE2sXAjcLXR/69LWOe/oxavBLOrenZcTzvTXn83jqAGqY+OuwF+2kFXzbKtDA==",
+          "requires": {
+            "color": "^4.2.0",
+            "detect-libc": "^2.0.0",
+            "node-addon-api": "^4.3.0",
+            "prebuild-install": "^7.0.1",
+            "semver": "^7.3.5",
+            "simple-get": "^4.0.1",
+            "tar-fs": "^2.1.1",
+            "tunnel-agent": "^0.6.0"
+          }
         },
         "token-types": {
           "version": "2.1.1",
@@ -51145,6 +50938,18 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "lmdb": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.2.tgz",
+      "integrity": "sha512-ih7wahPRxy19T+r6/vN9UfdpDfIPXlLL/PkRVkDuNPA/MNGZIiGM/v1zUyhC/+4sveponuQRHVObt8sTVrW8rw==",
+      "requires": {
+        "msgpackr": "^1.5.4",
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
+      }
+    },
     "lmdb-store": {
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/lmdb-store/-/lmdb-store-1.6.13.tgz",
@@ -52248,10 +52053,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msgpackr": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.0.tgz",
-      "integrity": "sha512-GWMowA95SOMkrFM+uKF/9MOIoZbDwoZ09XEqSoOwyt/IzohTfxfOJrIGW0fInvcZUEoZ0wHCwVg4K0UOOUA49A==",
-      "optional": true,
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.5.4.tgz",
+      "integrity": "sha512-Z7w5Jg+2Q9z9gJxeM68d7tSuWZZGnFIRhZnyqcZCa/1dKkhOCNvR1TUV3zzJ3+vj78vlwKRzUgVDlW4jiSOeDA==",
       "requires": {
         "msgpackr-extract": "^1.0.14"
       }
@@ -52393,9 +52197,9 @@
       }
     },
     "node-addon-api": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.2.0.tgz",
-      "integrity": "sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node-dir": {
       "version": "0.1.17",
@@ -52837,9 +52641,9 @@
       }
     },
     "ordered-binary": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.1.3.tgz",
-      "integrity": "sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ=="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.2.4.tgz",
+      "integrity": "sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg=="
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -54161,11 +53965,11 @@
       }
     },
     "prebuild-install": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.0.tgz",
-      "integrity": "sha512-IvSenf33K7JcgddNz2D5w521EgO+4aMMjFt73Uk9FRzQ7P+QZPKrp7qPsDydsSwjGt3T5xRNnM1bj1zMTD5fTA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.0.1.tgz",
+      "integrity": "sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==",
       "requires": {
-        "detect-libc": "^1.0.3",
+        "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
@@ -54178,6 +53982,13 @@
         "simple-get": "^4.0.0",
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
+      },
+      "dependencies": {
+        "detect-libc": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+          "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+        }
       }
     },
     "prelude-ls": {
@@ -56184,9 +55995,9 @@
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.0.tgz",
-      "integrity": "sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -59211,9 +59022,9 @@
       }
     },
     "weak-lru-cache": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.1.3.tgz",
-      "integrity": "sha512-5LDIv+sr6uzT94Hhcq7Qv7gt3jxol4iMWUqOgJSLYbB5oO7bTSMqIBtKsytm8N2BufYOdJw86/qu+SDfbo/wKQ=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
+      "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw=="
     },
     "web-namespaces": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gatsby-image": "^3.11.0",
     "gatsby-plugin-feed": "^4.7.0",
     "gatsby-plugin-image": "^2.7.0",
-    "gatsby-source-wordpress": "^6.7.0-alpha-gatsby-source-wordpress.7",
+    "gatsby-source-wordpress": "^6.8.0",
     "html-react-parser": "^1.4.2",
     "lottie-web": "5.8.1",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
This PR brings `gatsby-source-wordpress` plugin 6.8.0 version update
The images in Safari are displayed correctly, tested via Browserstack